### PR TITLE
Fix duppr link

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
 		<LI>Zhixing Li, <strong>Yue Yu (corresponding author)</strong>, Minghui Zhou, Tao Wang, Gang Yin, Long Lan, and Huaimin Wang.
 		<strong>Redundancy, Context, and Preference: An Empirical Study of Duplicate Pull Requests in OSS Projects</strong>.		
 		IEEE Transactions on Software Engineering (TSE), 2020. (SCI, CCF-A)
-		[<A href="res/paper/dupPR_TSE2020.pdf">pdf</A>][<A href="https://github.com/whystar/DupPR-cited">data</A>]
+		[<A href="res/paper/dupPR_TSE2020.pdf">pdf</A>][<A href="https://github.com/whystar/MSR2018-DupPR">data</A>]
 		
 		<LI>Haoran Liu, <strong>Yue Yu (corresponding author)</strong>, Shanshan Li, Yong Guo, Deze Wang, Xiaoguang Mao.
 		<strong>BugSum: Deep Context Understanding for Bug Report Summarization</strong>.		

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
 		<LI>Zhixing Li, <strong>Yue Yu (corresponding author)</strong>, Minghui Zhou, Tao Wang, Gang Yin, Long Lan, and Huaimin Wang.
 		<strong>Redundancy, Context, and Preference: An Empirical Study of Duplicate Pull Requests in OSS Projects</strong>.		
 		IEEE Transactions on Software Engineering (TSE), 2020. (SCI, CCF-A)
-		[<A href="res/paper/dupPR_TSE2020.pdf">pdf</A>][<A href="https://github.com/whystar/MSR2018-DupPR">data</A>]
+		[<A href="res/paper/Dup_TSE_version.pdf">pdf</A>][<A href="https://github.com/whystar/MSR2018-DupPR">data</A>]
 		
 		<LI>Haoran Liu, <strong>Yue Yu (corresponding author)</strong>, Shanshan Li, Yong Guo, Deze Wang, Xiaoguang Mao.
 		<strong>BugSum: Deep Context Understanding for Bug Report Summarization</strong>.		


### PR DESCRIPTION
Two changes in this PR:

1. change to the link of the real dataset repo
2. change to show the latest version of duppr paper